### PR TITLE
Move .vim file to plugin dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ any matching entries to standard output.
 
 Vim installation
 ----------------
-Download the plugin:
+If you use vim-plug:
+
+```vim
+Plug 'dnmfarrell/WebsterSearch'
+```
+
+or download the plugin:
 
     $ mkdir ~/.vim/plugin
     $ cd ~/.vim/plugin

--- a/plugin/webster-search.vim
+++ b/plugin/webster-search.vim
@@ -1,7 +1,7 @@
 let s:parent_dir = expand('<sfile>:p:h')
 
 function! WebsterSearch(term)
-  let l:perl_script = 'webster-search.pl'
+  let l:perl_script = '../webster-search.pl'
   let l:command =  s:parent_dir . '/' . l:perl_script . ' ' . a:term
   execute "let output = system('" . l:command . "')"
   vnew


### PR DESCRIPTION
This allows it to work out of the box with vim-plug.

I saw your article this morning and I wondered what it would take to get it to work with `vim-plug`.  Turns out the changes are not invasive, but I'm not sure if this will still work with your instructions for the manual download.

I did a quick search of some other plugins and Google and it looks like the `plugin` folder is a standard place to put this file.  https://www.oreilly.com/library/view/the-viml-primer/9781680500585/f_0015.html